### PR TITLE
Task priority with builder

### DIFF
--- a/ServiceEssentials.xcodeproj/project.pbxproj
+++ b/ServiceEssentials.xcodeproj/project.pbxproj
@@ -750,6 +750,7 @@
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = ServiceEssentialsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(FRAMEWORK_SEARCH_PATHS)";
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.service-essentials.ServiceEssentialsTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -766,6 +767,7 @@
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = ServiceEssentialsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(FRAMEWORK_SEARCH_PATHS)";
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.service-essentials.ServiceEssentialsTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -822,6 +824,7 @@
 				D5EED1911D20B678009DCDDD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/ServiceEssentials/Services/DataRequestService/SEDataRequestService.h
+++ b/ServiceEssentials/Services/DataRequestService/SEDataRequestService.h
@@ -60,6 +60,16 @@ typedef enum
     SENetworkReachabilityStatusReachableViaWWAN = 5
 } SENetworkReachabilityStatus;
 
+typedef enum
+{
+    SEDataRequestQOSDefault = QOS_CLASS_UNSPECIFIED,
+    SEDataRequestQOSPriorityBackground = QOS_CLASS_BACKGROUND,
+    SEDataRequestQOSPriorityLow = QOS_CLASS_UTILITY,
+    SEDataRequestQOSPriorityNormal = QOS_CLASS_DEFAULT,
+    SEDataRequestQOSPriorityHigh = QOS_CLASS_USER_INITIATED,
+    SEDataRequestQOSPriorityInteractive = QOS_CLASS_USER_INTERACTIVE
+} SEDataRequestQualityOfService;
+
 @protocol SEDataRequestCustomizer <NSObject>
 /** 
  Finalizes the requests and submits it. This method must be invoked in the end of the building to make the request. 
@@ -70,6 +80,13 @@ typedef enum
 - (nonnull id<SECancellableToken>) submitAsUpload: (BOOL) asUpload;
 /** Convenience shorthand method for `submitAsUpload:`. Will determine how to submit based on parameters. */
 - (nonnull id<SECancellableToken>) submit;
+
+/** 
+ Set request quality of service. If the value is not set or set to SEDataRequestQOSDefault,
+ requests are performed with default priority - that is, default request priority 
+ and parsing on a service's internal queue.
+ */
+- (void) setQualityOfService:(SEDataRequestQualityOfService)qualityOfService;
 
 /** Set class to deserialize the data to. Will deserialize from JSON, mutually exclusive with raw data. */
 - (void) setDeserializeClass: (nonnull Class) class;

--- a/ServiceEssentials/Services/DataRequestService/SEDataRequestServiceImpl.m
+++ b/ServiceEssentials/Services/DataRequestService/SEDataRequestServiceImpl.m
@@ -96,7 +96,6 @@ static inline float SEDataRequestServiceTaskPriorityForQOS(const SEDataRequestQu
     NSMutableDictionary<id<SECancellableToken>, SEInternalDataRequest *> *_internalRequestsByKey;
     NSMutableDictionary<NSNumber *, SEInternalDataRequest *> *_internalRequestsByTask;
     pthread_mutex_t _lock;
-    dispatch_queue_t _internalProcessingQueue;
     
     NSDictionary *_dataSerializers;
     SEDataSerializer *_defaultSerializer;
@@ -132,7 +131,6 @@ static inline float SEDataRequestServiceTaskPriorityForQOS(const SEDataRequestQu
         _internalRequestsByKey = [[NSMutableDictionary alloc] initWithCapacity:1];
         _internalRequestsByTask = [[NSMutableDictionary alloc] initWithCapacity:1];
         pthread_mutex_init(&_lock, NULL);
-        _internalProcessingQueue = dispatch_queue_create("com.service-essentials.DataRequestServiceQueue", DISPATCH_QUEUE_CONCURRENT);
         
         _defaultSerializer = [SEDataSerializer new];
         SEDataSerializer *plainTextDeserializer = [SEPlainTextSerializer new];

--- a/ServiceEssentials/Services/DataRequestService/SEDataRequestServiceImpl.m
+++ b/ServiceEssentials/Services/DataRequestService/SEDataRequestServiceImpl.m
@@ -62,8 +62,23 @@ NSInteger const SEDataRequestServiceRequestBuilderFailure = SEDataRequestService
 
 NSString * _Nonnull const SEDataRequestServiceErrorDeserializedContentKey = @"ErrorDeserializedContentKey";
 
-static NSString * _Nonnull const SEDataRequestServiceBackgroundTaskId = @"com.service-essentials.DataRequestServiceService.background";
+static NSString * _Nonnull const SEDataRequestServiceBackgroundTaskId = @"com.service-essentials.DataRequestService.background";
 
+static inline float SEDataRequestServiceTaskPriorityForQOS(const SEDataRequestQualityOfService qos)
+{
+    switch (qos) {
+        case SEDataRequestQOSPriorityLow:
+        case SEDataRequestQOSPriorityBackground:
+            return NSURLSessionTaskPriorityLow;
+        case SEDataRequestQOSPriorityHigh:
+        case SEDataRequestQOSPriorityInteractive:
+            return NSURLSessionTaskPriorityHigh;
+        case SEDataRequestQOSDefault:
+        case SEDataRequestQOSPriorityNormal:
+        default:
+            return NSURLSessionTaskPriorityDefault;
+    }
+}
 
 @interface SEDataRequestServiceImpl () <NSURLSessionDelegate, NSURLSessionDataDelegate, NSURLSessionDownloadDelegate, SEDataRequestServicePrivate, SENetworkReachabilityTrackerDelegate>
 @end
@@ -80,6 +95,7 @@ static NSString * _Nonnull const SEDataRequestServiceBackgroundTaskId = @"com.se
     NSMutableDictionary<id<SECancellableToken>, SEInternalDataRequest *> *_internalRequestsByKey;
     NSMutableDictionary<NSNumber *, SEInternalDataRequest *> *_internalRequestsByTask;
     NSLock *_lock;
+    dispatch_queue_t _internalProcessingQueue;
     
     NSDictionary *_dataSerializers;
     SEDataSerializer *_defaultSerializer;
@@ -115,6 +131,7 @@ static NSString * _Nonnull const SEDataRequestServiceBackgroundTaskId = @"com.se
         _internalRequestsByKey = [[NSMutableDictionary alloc] initWithCapacity:1];
         _internalRequestsByTask = [[NSMutableDictionary alloc] initWithCapacity:1];
         _lock = [[NSLock alloc] init];
+        _internalProcessingQueue = dispatch_queue_create("com.service-essentials.DataRequestServiceQueue", DISPATCH_QUEUE_CONCURRENT);
         
         _defaultSerializer = [SEDataSerializer new];
         SEDataSerializer *plainTextDeserializer = [SEPlainTextSerializer new];
@@ -155,8 +172,8 @@ static NSString * _Nonnull const SEDataRequestServiceBackgroundTaskId = @"com.se
 
 - (void)dealloc
 {
-    [_session invalidateAndCancel];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [_session invalidateAndCancel];
 }
 
 - (void) onWillTerminateApplication: (NSNotification *) notification
@@ -302,7 +319,7 @@ static NSString * _Nonnull const SEDataRequestServiceBackgroundTaskId = @"com.se
     {
         NSMutableURLRequest *request = [self createRequestWithMethod:@"GET" authorized:YES url:url data:nil contentType:nil acceptContentType:SEDataRequestAcceptContentTypeData charset:nil];
         
-        return [self createDownloadRequestWithURLRequest:request saveFileAs:saveAsURL expectedHTTPCodes:nil success:success failure:failure progress:progress completionQueue:completionQueue];
+        return [self createDownloadRequestWithURLRequest:request qos:SEDataRequestQOSDefault saveFileAs:saveAsURL expectedHTTPCodes:nil success:success failure:failure progress:progress completionQueue:completionQueue];
     }
 }
 
@@ -359,7 +376,7 @@ static NSString * _Nonnull const SEDataRequestServiceBackgroundTaskId = @"com.se
     
     NSMutableURLRequest *request = [self createRequestWithMethod:@"GET" authorized:NO url:url data:nil contentType:nil acceptContentType:SEDataRequestAcceptContentTypeData charset:nil];
 
-    return [self createDataRequestWithURLRequest:request dataClass:nil expectedHTTPCodes:nil success:success failure:failure completionQueue:completionQueue];
+    return [self createDataRequestWithURLRequest:request qos:SEDataRequestQOSDefault dataClass:nil expectedHTTPCodes:nil success:success failure:failure completionQueue:completionQueue];
 }
 
 - (id<SECancellableToken>)URLDownload:(NSURL *)url parameters:(NSDictionary<NSString *,id> *)parameters saveAs:(NSURL *)saveAsURL success:(void (^)(id _Nullable, NSURLResponse * _Nonnull))success failure:(void (^)(NSError * _Nonnull))failure progress:(void (^)(int64_t, int64_t, int64_t))progress completionQueue:(dispatch_queue_t)completionQueue
@@ -371,7 +388,7 @@ static NSString * _Nonnull const SEDataRequestServiceBackgroundTaskId = @"com.se
     
     NSMutableURLRequest *request = [self createRequestWithMethod:@"GET" authorized:NO url:url data:nil contentType:nil acceptContentType:SEDataRequestAcceptContentTypeData charset:nil];
 
-    return [self createDownloadRequestWithURLRequest:request saveFileAs:saveAsURL expectedHTTPCodes:nil success:success failure:failure progress:progress completionQueue:completionQueue];
+    return [self createDownloadRequestWithURLRequest:request qos:SEDataRequestQOSPriorityLow saveFileAs:saveAsURL expectedHTTPCodes:nil success:success failure:failure progress:progress completionQueue:completionQueue];
 }
 
 #pragma mark - Private interface
@@ -446,11 +463,11 @@ static NSString * _Nonnull const SEDataRequestServiceBackgroundTaskId = @"com.se
             
             if (asUpload)
             {
-                return [self createDataRequestWithURLRequest:baseRequest dataClass:requestBuilder.deserializeClass expectedHTTPCodes:requestBuilder.expectedHTTPCodes success:requestBuilder.success failure:requestBuilder.failure completionQueue:requestBuilder.completionQueue];
+                return [self createDataRequestWithURLRequest:baseRequest qos:requestBuilder.qualityOfService dataClass:requestBuilder.deserializeClass expectedHTTPCodes:requestBuilder.expectedHTTPCodes success:requestBuilder.success failure:requestBuilder.failure completionQueue:requestBuilder.completionQueue];
             }
             else
             {
-                return [self createUploadRequestWithURLRequest:baseRequest data:baseRequest.HTTPBody dataClass:requestBuilder.deserializeClass expectedHTTPCodes:requestBuilder.expectedHTTPCodes success:requestBuilder.success failure:requestBuilder.failure completionQueue:requestBuilder.completionQueue];
+                return [self createUploadRequestWithURLRequest:baseRequest qos:requestBuilder.qualityOfService data:baseRequest.HTTPBody dataClass:requestBuilder.deserializeClass expectedHTTPCodes:requestBuilder.expectedHTTPCodes success:requestBuilder.success failure:requestBuilder.failure completionQueue:requestBuilder.completionQueue];
             }
         }
     }
@@ -468,7 +485,7 @@ static NSString * _Nonnull const SEDataRequestServiceBackgroundTaskId = @"com.se
         unsigned long long contentLength = [SEMultipartRequestContentStream contentLengthForParts:requestBuilder.contentParts boundary:boundary stringEncoding:SEDataRequestServiceStringEncoding];
             [baseRequest setValue:[NSString stringWithFormat:@"%llu", contentLength] forHTTPHeaderField:@"Content-Length"];
             
-        return [self createStreamedUploadRequestWithURLRequest:baseRequest dataClass:requestBuilder.deserializeClass expectedHTTPCodes:requestBuilder.expectedHTTPCodes multipartContents:requestBuilder.contentParts boundary:boundary success:requestBuilder.success failure:requestBuilder.failure completionQueue:requestBuilder.completionQueue];
+        return [self createStreamedUploadRequestWithURLRequest:baseRequest qos:requestBuilder.qualityOfService dataClass:requestBuilder.deserializeClass expectedHTTPCodes:requestBuilder.expectedHTTPCodes multipartContents:requestBuilder.contentParts boundary:boundary success:requestBuilder.success failure:requestBuilder.failure completionQueue:requestBuilder.completionQueue];
     }
     
     if (error && requestBuilder.failure != nil)
@@ -625,7 +642,7 @@ static NSString * _Nonnull const SEDataRequestServiceBackgroundTaskId = @"com.se
     
     if (urlRequest != nil)
     {
-        return [self createDataRequestWithURLRequest:urlRequest dataClass:class expectedHTTPCodes:nil success:success failure:failure completionQueue:completionQueue];
+        return [self createDataRequestWithURLRequest:urlRequest qos:SEDataRequestQOSDefault dataClass:class expectedHTTPCodes:nil success:success failure:failure completionQueue:completionQueue];
     }
     else
     {
@@ -635,44 +652,45 @@ static NSString * _Nonnull const SEDataRequestServiceBackgroundTaskId = @"com.se
 }
 
 /** Creates and submits standard data task */
-- (id<SECancellableToken>) createDataRequestWithURLRequest: (NSURLRequest *) urlRequest dataClass:(Class) dataClass expectedHTTPCodes:(NSIndexSet *)expectedCodes success:(void (^)(id, NSURLResponse *))success failure:(void (^)(NSError *))failure completionQueue:(dispatch_queue_t)completionQueue
+- (id<SECancellableToken>) createDataRequestWithURLRequest: (NSURLRequest *) urlRequest qos: (SEDataRequestQualityOfService) qos dataClass:(Class) dataClass expectedHTTPCodes:(NSIndexSet *)expectedCodes success:(void (^)(id, NSURLResponse *))success failure:(void (^)(NSError *))failure completionQueue:(dispatch_queue_t)completionQueue
 {
     NSURLSessionDataTask *dataTask = [_session dataTaskWithRequest:urlRequest];
-    return [self createInternalRequestWithTask:dataTask dataClass:dataClass expectedHTTPCodes:expectedCodes multipartContents:nil downloadParameters:nil success:success failure:failure completionQueue:completionQueue];
+    return [self createInternalRequestWithTask:dataTask qos:qos dataClass:dataClass expectedHTTPCodes:expectedCodes multipartContents:nil downloadParameters:nil success:success failure:failure completionQueue:completionQueue];
 }
 
 /** Creates and submits upload data task with provided data */
-- (id<SECancellableToken>) createUploadRequestWithURLRequest: (NSURLRequest *) urlRequest data:(NSData *) data dataClass:(Class) dataClass expectedHTTPCodes:(NSIndexSet *)expectedCodes success:(void (^)(id, NSURLResponse *))success failure:(void (^)(NSError *))failure completionQueue:(dispatch_queue_t)completionQueue
+- (id<SECancellableToken>) createUploadRequestWithURLRequest: (NSURLRequest *) urlRequest qos: (SEDataRequestQualityOfService) qos data:(NSData *) data dataClass:(Class) dataClass expectedHTTPCodes:(NSIndexSet *)expectedCodes success:(void (^)(id, NSURLResponse *))success failure:(void (^)(NSError *))failure completionQueue:(dispatch_queue_t)completionQueue
 {
     NSURLSessionDataTask *dataTask = [_session uploadTaskWithRequest:urlRequest fromData:data];
-    return [self createInternalRequestWithTask:dataTask dataClass:dataClass expectedHTTPCodes:expectedCodes multipartContents:nil downloadParameters:nil success:success failure:failure completionQueue:completionQueue];
+    return [self createInternalRequestWithTask:dataTask qos:qos dataClass:dataClass expectedHTTPCodes:expectedCodes multipartContents:nil downloadParameters:nil success:success failure:failure completionQueue:completionQueue];
 }
 
 /** Creates and submits upload data task with a file */
-- (id<SECancellableToken>) createUploadRequestWithURLRequest: (NSURLRequest *) urlRequest file:(NSURL *) dataFile dataClass:(Class) dataClass expectedHTTPCodes:(NSIndexSet *)expectedCodes success:(void (^)(id, NSURLResponse *))success failure:(void (^)(NSError *))failure completionQueue:(dispatch_queue_t)completionQueue
+- (id<SECancellableToken>) createUploadRequestWithURLRequest: (NSURLRequest *) urlRequest qos:(SEDataRequestQualityOfService)qos file:(NSURL *) dataFile dataClass:(Class) dataClass expectedHTTPCodes:(NSIndexSet *)expectedCodes success:(void (^)(id, NSURLResponse *))success failure:(void (^)(NSError *))failure completionQueue:(dispatch_queue_t)completionQueue
 {
     NSURLSessionDataTask *dataTask = [_session uploadTaskWithRequest:urlRequest fromFile:dataFile];
-    return [self createInternalRequestWithTask:dataTask dataClass:dataClass expectedHTTPCodes:expectedCodes multipartContents:nil downloadParameters:nil success:success failure:failure completionQueue:completionQueue];
+    return [self createInternalRequestWithTask:dataTask qos:qos dataClass:dataClass expectedHTTPCodes:expectedCodes multipartContents:nil downloadParameters:nil success:success failure:failure completionQueue:completionQueue];
 }
 
 /** Creates and submits streamed uploda data task - will have to provide the stream as well. Will use for some of the multipart submissions. */
-- (id<SECancellableToken>) createStreamedUploadRequestWithURLRequest: (NSURLRequest *) urlRequest dataClass:(Class) dataClass expectedHTTPCodes:(NSIndexSet *)expectedCodes multipartContents:(NSArray *)multipartContents boundary:(NSString *)boundary success:(void (^)(id, NSURLResponse *))success failure:(void (^)(NSError *))failure completionQueue:(dispatch_queue_t)completionQueue
+- (id<SECancellableToken>) createStreamedUploadRequestWithURLRequest: (NSURLRequest *) urlRequest qos:(SEDataRequestQualityOfService)qos dataClass:(Class) dataClass expectedHTTPCodes:(NSIndexSet *)expectedCodes multipartContents:(NSArray *)multipartContents boundary:(NSString *)boundary success:(void (^)(id, NSURLResponse *))success failure:(void (^)(NSError *))failure completionQueue:(dispatch_queue_t)completionQueue
 {
     NSURLSessionUploadTask *dataTask = [_session uploadTaskWithStreamedRequest:urlRequest];
     SEInternalMultipartContents *multipartParameters = (multipartContents == nil || boundary == nil) ? nil : [[SEInternalMultipartContents alloc] initWithMultipartContents:multipartContents boundary:boundary];
-    return [self createInternalRequestWithTask:dataTask dataClass:dataClass expectedHTTPCodes:expectedCodes multipartContents:multipartParameters downloadParameters:nil success:success failure:failure completionQueue:completionQueue];
+    return [self createInternalRequestWithTask:dataTask qos:qos dataClass:dataClass expectedHTTPCodes:expectedCodes multipartContents:multipartParameters downloadParameters:nil success:success failure:failure completionQueue:completionQueue];
 }
 
-- (id<SECancellableToken>) createDownloadRequestWithURLRequest: (NSURLRequest *) urlRequest saveFileAs: (NSURL *) saveAs expectedHTTPCodes:(NSIndexSet *)expectedCodes success:(void (^)(id, NSURLResponse *))success failure:(void (^)(NSError *))failure progress:(void (^)(int64_t, int64_t, int64_t))progress completionQueue:(dispatch_queue_t)completionQueue
+- (id<SECancellableToken>) createDownloadRequestWithURLRequest: (NSURLRequest *) urlRequest qos:(SEDataRequestQualityOfService)qos saveFileAs: (NSURL *) saveAs expectedHTTPCodes:(NSIndexSet *)expectedCodes success:(void (^)(id, NSURLResponse *))success failure:(void (^)(NSError *))failure progress:(void (^)(int64_t, int64_t, int64_t))progress completionQueue:(dispatch_queue_t)completionQueue
 {
     NSURLSessionDownloadTask *downloadTask = [_session downloadTaskWithRequest:urlRequest];
     SEInternalDownloadRequestParameters *downloadRequestParameters = [[SEInternalDownloadRequestParameters alloc] initWithSaveAsURL:saveAs downloadProgressCallback:progress];
-    return [self createInternalRequestWithTask:downloadTask dataClass:nil expectedHTTPCodes:nil multipartContents:nil downloadParameters:downloadRequestParameters success:success failure:failure completionQueue:completionQueue];
+    return [self createInternalRequestWithTask:downloadTask qos:qos dataClass:nil expectedHTTPCodes:nil multipartContents:nil downloadParameters:downloadRequestParameters success:success failure:failure completionQueue:completionQueue];
 }
 
-- (id<SECancellableToken>) createInternalRequestWithTask: (NSURLSessionTask *) dataTask dataClass:(Class) dataClass expectedHTTPCodes:(NSIndexSet *)expectedCodes multipartContents:(SEInternalMultipartContents *)multipartContents downloadParameters:(SEInternalDownloadRequestParameters *)downloadParameters success:(void (^)(id, NSURLResponse *))success failure:(void (^)(NSError *))failure completionQueue:(dispatch_queue_t)completionQueue
+- (id<SECancellableToken>) createInternalRequestWithTask: (NSURLSessionTask *) dataTask qos:(SEDataRequestQualityOfService)qos dataClass:(Class) dataClass expectedHTTPCodes:(NSIndexSet *)expectedCodes multipartContents:(SEInternalMultipartContents *)multipartContents downloadParameters:(SEInternalDownloadRequestParameters *)downloadParameters success:(void (^)(id, NSURLResponse *))success failure:(void (^)(NSError *))failure completionQueue:(dispatch_queue_t)completionQueue
 {
-    SEInternalDataRequest *internalRequest = [[SEInternalDataRequest alloc] initWithSessionTask:dataTask requestService:self responseDataClass:dataClass expectedHTTPCodes:expectedCodes multipartContents:multipartContents downloadParameters:downloadParameters success:success failure:failure completionQueue:completionQueue];
+    dataTask.priority = SEDataRequestServiceTaskPriorityForQOS(qos);
+    SEInternalDataRequest *internalRequest = [[SEInternalDataRequest alloc] initWithSessionTask:dataTask requestService:self qualityOfService:qos responseDataClass:dataClass expectedHTTPCodes:expectedCodes multipartContents:multipartContents downloadParameters:downloadParameters success:success failure:failure completionQueue:completionQueue];
     
     @try
     {

--- a/ServiceEssentials/Services/DataRequestService/SEDataRequestServicePrivate.h
+++ b/ServiceEssentials/Services/DataRequestService/SEDataRequestServicePrivate.h
@@ -21,6 +21,20 @@ typedef enum {
 #endif // ServiceEssentials_DataRequestServicePrivate_h
 
 #import "SEDataRequestServiceImpl.h"
+#import "SETools.h"
+
+static inline void SEDataRequestVerifyQOS(SEDataRequestQualityOfService qualityOfService)
+{
+    if (   qualityOfService != SEDataRequestQOSDefault
+        && qualityOfService != SEDataRequestQOSPriorityBackground
+        && qualityOfService != SEDataRequestQOSPriorityLow
+        && qualityOfService != SEDataRequestQOSPriorityNormal
+        && qualityOfService != SEDataRequestQOSPriorityHigh
+        && qualityOfService != SEDataRequestQOSPriorityInteractive)
+    {
+        THROW_INVALID_PARAM(qualityOfService, @{ NSLocalizedDescriptionKey: @"Unrecognized quality of service (QOS) value." });
+    }
+}
 
 @protocol SECancellableToken;
 @class SEInternalDataRequest;

--- a/ServiceEssentials/Services/DataRequestService/SEInternalDataRequest.h
+++ b/ServiceEssentials/Services/DataRequestService/SEInternalDataRequest.h
@@ -9,6 +9,7 @@
 //
 
 @import Foundation;
+#import "SEDataRequestService.h"
 
 @protocol SEDataRequestServicePrivate;
 @protocol SECancellableToken;
@@ -28,10 +29,11 @@
 
 @interface SEInternalDataRequest : NSObject
 
-- (instancetype) initWithSessionTask: (NSURLSessionTask *) task requestService:(id<SEDataRequestServicePrivate>) requestService responseDataClass: (Class) dataClass expectedHTTPCodes:(NSIndexSet *)expectedCodes multipartContents: (SEInternalMultipartContents *) multipartContents downloadParameters: (SEInternalDownloadRequestParameters *) downloadParameters success: (void(^)(id, NSURLResponse *)) success failure: (void (^)(NSError *)) failure completionQueue: (dispatch_queue_t) completionQueue;
+- (instancetype) initWithSessionTask: (NSURLSessionTask *) task requestService:(id<SEDataRequestServicePrivate>) requestService qualityOfService:(SEDataRequestQualityOfService)qualityOfService responseDataClass: (Class) dataClass expectedHTTPCodes:(NSIndexSet *)expectedCodes multipartContents: (SEInternalMultipartContents *) multipartContents downloadParameters: (SEInternalDownloadRequestParameters *) downloadParameters success: (void(^)(id, NSURLResponse *)) success failure: (void (^)(NSError *)) failure completionQueue: (dispatch_queue_t) completionQueue;
 
 @property (nonatomic, readonly, retain) id<SECancellableToken> token;
 @property (nonatomic, readonly, retain) NSURLSessionTask *task;
+@property (nonatomic, readonly, assign) SEDataRequestQualityOfService qualityOfService;
 
 @property (nonatomic, readonly, assign) BOOL isCompleted;
 

--- a/ServiceEssentials/Services/DataRequestService/SEInternalDataRequest.m
+++ b/ServiceEssentials/Services/DataRequestService/SEInternalDataRequest.m
@@ -23,18 +23,6 @@
 #define COMPLETED_REQUEST_BIT       0 // signals that request has been completed
 #define CANCELLED_REQUEST_BIT       1 // signals that request has been cancelled, this bit will also be set by completed callback
 
-static inline dispatch_queue_t SEDataRequestQueueForQOS(SEDataRequestQualityOfService qos, dispatch_queue_t privateQueue)
-{
-#ifdef DEBUG
-    if (privateQueue == nil) THROW_INVALID_PARAM(privateQueue, nil);
-#endif
-    if (qos == SEDataRequestQOSDefault) return privateQueue;
-    
-    dispatch_queue_t result = dispatch_get_global_queue(qos, 0);
-    if (result == nil) THROW_INVALID_PARAM(qos, nil);
-    return result;
-}
-
 static inline void SEDataRequestSendCompletionToService(id<SEDataRequestServicePrivate> service, SEInternalDataRequest *request)
 {
     if (service)

--- a/ServiceEssentials/Services/DataRequestService/SEInternalDataRequest.m
+++ b/ServiceEssentials/Services/DataRequestService/SEInternalDataRequest.m
@@ -23,6 +23,28 @@
 #define COMPLETED_REQUEST_BIT       0 // signals that request has been completed
 #define CANCELLED_REQUEST_BIT       1 // signals that request has been cancelled, this bit will also be set by completed callback
 
+static inline dispatch_queue_t SEDataRequestQueueForQOS(SEDataRequestQualityOfService qos, dispatch_queue_t privateQueue)
+{
+#ifdef DEBUG
+    if (privateQueue == nil) THROW_INVALID_PARAM(privateQueue, nil);
+#endif
+    if (qos == SEDataRequestQOSDefault) return privateQueue;
+    
+    dispatch_queue_t result = dispatch_get_global_queue(qos, 0);
+    if (result == nil) THROW_INVALID_PARAM(qos, nil);
+    return result;
+}
+
+static inline void SEDataRequestSendCompletionToService(id<SEDataRequestServicePrivate> service, SEInternalDataRequest *request)
+{
+    if (service)
+    {
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0), ^{
+            [service completeInternalRequest:request];
+        });
+    }
+}
+
 @implementation SEInternalDataRequest
 {
     __weak id<SEDataRequestServicePrivate> _requestService;
@@ -39,14 +61,16 @@
     NSURLResponse *_response;
 }
 
-- (instancetype)initWithSessionTask:(NSURLSessionTask *)task requestService:(id<SEDataRequestServicePrivate>)requestService responseDataClass:(Class)dataClass expectedHTTPCodes:(NSIndexSet *)expectedCodes multipartContents:(SEInternalMultipartContents *)multipartContents downloadParameters:(SEInternalDownloadRequestParameters *)downloadParameters success:(void (^)(id, NSURLResponse *))success failure:(void (^)(NSError *))failure completionQueue:(dispatch_queue_t)completionQueue
+- (instancetype)initWithSessionTask:(NSURLSessionTask *)task requestService:(id<SEDataRequestServicePrivate>)requestService qualityOfService:(SEDataRequestQualityOfService)qualityOfService responseDataClass:(__unsafe_unretained Class)dataClass expectedHTTPCodes:(NSIndexSet *)expectedCodes multipartContents:(SEInternalMultipartContents *)multipartContents downloadParameters:(SEInternalDownloadRequestParameters *)downloadParameters success:(void (^)(id, NSURLResponse *))success failure:(void (^)(NSError *))failure completionQueue:(dispatch_queue_t)completionQueue
 {
     self = [super init];
     if (self)
     {
         _requestService = requestService;
+        
         _expectedHTTPCodes = expectedCodes ?: [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(200, 100)];
         _task = task;
+        _qualityOfService = qualityOfService;
         _dataClass = dataClass;
         _multipartContents = multipartContents;
         _downloadRequestParameters = downloadParameters;
@@ -66,7 +90,31 @@
     if (!wasCompleted)
     {
         [_task cancel];
-        [self sendFailureAndComplete:[NSError errorWithDomain:SEErrorDomain code:SEDataRequestServiceRequestCancelled userInfo:nil] checkBeforeCallback:NO];
+        
+        // cannot do anything that causes a retain of self, need to be very careful
+        // cannot make a block that uses self
+        // cannot make an async block because self will be gone
+        // better to avoid any calls to self at all
+        // call the service method synchronously
+
+        void (^failureBlock)(NSError *) = _failure;
+        NSError *error = [NSError errorWithDomain:SEErrorDomain code:SEDataRequestServiceRequestCancelled userInfo:nil];
+        if (failureBlock)
+        {
+            dispatch_async(_completionQueue, ^{
+                failureBlock(error);
+            });
+        }
+
+        
+#ifdef DEBUG
+        if (_requestService) {
+            NSLog(@"ERROR: the service is not deallocated and request is not complete, this should never happen!");
+        }
+#endif
+        
+        __unsafe_unretained typeof (self) unretainedSelf = self;
+        [_requestService completeInternalRequest:unretainedSelf];
     }
 }
 
@@ -84,7 +132,7 @@
     {
         OSAtomicTestAndSet(CANCELLED_REQUEST_BIT, &_completed);
         [_task cancel];
-        [self sendCompletionBack];
+        SEDataRequestSendCompletionToService(_requestService, self);
     }
 }
 
@@ -125,14 +173,13 @@
     
 #ifdef DEBUG
         // double-ensure
-        if (   _dataClass != nil && ![SEDataRequestServiceImpl canDeserializeToClass:_dataClass])
+        if (_dataClass != nil && ![SEDataRequestServiceImpl canDeserializeToClass:_dataClass])
         {
             error = [NSError errorWithDomain:SEErrorDomain code:SEDataRequestServiceSerializationFailure userInfo:@{ NSLocalizedDescriptionKey: @"FAILURE: incorrect class for deserialization" }];
         }
 #endif
         if (error == nil && _dataClass != nil)
         {
-
             if ([result isKindOfClass:[NSDictionary class]])
             {
                 result = [_dataClass deserializeFromJSON: result];
@@ -197,7 +244,7 @@
         else
         {
             bool wasCompleted = OSAtomicTestAndSet(COMPLETED_REQUEST_BIT, &_completed);
-            if (!wasCompleted) [self sendCompletionBack];
+            if (!wasCompleted) SEDataRequestSendCompletionToService(_requestService, self);
         }
     }
     else
@@ -271,7 +318,7 @@
     bool wasCompleted = OSAtomicTestAndSet(COMPLETED_REQUEST_BIT, &_completed);
     if (wasCompleted) return;
     
-    [self sendCompletionBack];
+    SEDataRequestSendCompletionToService(_requestService, self);
     
     NSURLResponse *response = _response;
     void (^completion)(id, NSURLResponse *) = _success;
@@ -283,14 +330,6 @@
                 completion(result, response);
         });
     }
-}
-
-- (void) sendCompletionBack
-{
-    // this function assumes 'completed' bit has been checked and set
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0), ^{
-        [_requestService completeInternalRequest:self];
-    });
 }
 
 - (void) failedWithError: (NSError *) error
@@ -305,7 +344,7 @@
 - (void) sendFailureAndComplete: (NSError *) error checkBeforeCallback: (BOOL) checkBeforeCallback
 {
     // send completion first so that data service can perform the cleanup, then send the callback
-    [self sendCompletionBack];
+    SEDataRequestSendCompletionToService(_requestService, self);
     
     void (^failureBlock)(NSError *) = _failure;
     if (failureBlock)

--- a/ServiceEssentials/Services/DataRequestService/SEInternalDataRequestBuilder.h
+++ b/ServiceEssentials/Services/DataRequestService/SEInternalDataRequestBuilder.h
@@ -22,6 +22,8 @@
 @property (nonatomic, readonly, strong, nullable) void (^failure)(NSError * _Nonnull);
 @property (nonatomic, readonly, strong, nullable) dispatch_queue_t completionQueue;
 
+@property (nonatomic, readonly, assign) SEDataRequestQualityOfService qualityOfService;
+
 @property (nonatomic, readonly, assign, nullable) Class deserializeClass;
 @property (nonatomic, readonly, strong, nullable) NSString *contentEncoding;
 @property (nonatomic, readonly, assign) SEDataRequestAcceptContentType acceptContentType;

--- a/ServiceEssentialsTests/Services/DataRequestService/SEDataRequestBuilderTests.m
+++ b/ServiceEssentialsTests/Services/DataRequestService/SEDataRequestBuilderTests.m
@@ -243,7 +243,7 @@
     id<SEDataRequestCustomizer> customizer = [self createSimpleBuilderAndPost];
     [customizer setBodyParameters:@{ @"1": @2 }];
     NSError *error = nil;
-    XCTAssertThrows([customizer appendPartWithData:[self createSomeData] name:@"partName" mimeType:SEDataRequestServiceContentTypePlainText error:&error]);
+    XCTAssertFalse([customizer appendPartWithData:[self createSomeData] name:@"partName" mimeType:SEDataRequestServiceContentTypePlainText error:&error]);
 }
 
 - (void)testContentPartsAddDataPart
@@ -322,7 +322,7 @@
     NSError *error = nil;
     id<SEDataRequestCustomizer> customizer = [self createSimpleBuilderAndPost];
 
-    XCTAssertThrows([customizer appendPartWithFileURL:url name:name error:&error]);
+    XCTAssertFalse([customizer appendPartWithFileURL:url name:name error:&error]);
 }
 
 - (void)testContentPartsAddFilePartFileDoesNotExist
@@ -333,7 +333,7 @@
     NSError *error = nil;
     id<SEDataRequestCustomizer> customizer = [self createSimpleBuilderAndPost];
     
-    XCTAssertThrows([customizer appendPartWithFileURL:nonExistentUrl name:name error:&error]);
+    XCTAssertFalse([customizer appendPartWithFileURL:nonExistentUrl name:name error:&error]);
 }
 
 - (void)testContentPartsAddFilePartFileExists


### PR DESCRIPTION
1. Let the caller specify a request priority with request builder.
   Wanted to make the data parsing on a prioritized queue too, but for now leaving that idea alone since parsing happens in the context of the operation queue performing the data requests, which is fine.
2. Replace all `NSLock`'s with `pthread_mutex`'es.
3. Cleaned up `dealloc` for the data request class, since what it was doing is bad practice. Now better but not ideal.
