### PR TITLE
Fix persistence service unit tests

### DIFF
--- a/ServiceEssentialsTests/Services/SEPersistenceServiceTests.m
+++ b/ServiceEssentialsTests/Services/SEPersistenceServiceTests.m
@@ -54,8 +54,8 @@
     NSManagedObjectModel *model = [[NSManagedObjectModel alloc] init];
 
     NSEntityDescription *entity = [[NSEntityDescription alloc] init];
-    [entity setName:NSStringFromClass([SEPersistenceServiceTestModel class])];
-    [entity setManagedObjectClassName:@"PersistenceServiceTestModel"];
+    [entity setName:@"PersistenceServiceTestModel"];
+    [entity setManagedObjectClassName:NSStringFromClass([SEPersistenceServiceTestModel class])];
     
     NSMutableArray *properties = [NSMutableArray array];
     


### PR DESCRIPTION
Fix persistence service unit tests - mixed up the entity name and class name, and somehow it worked before but not anymore
