### PR TITLE
Request Factory tests

### DIFF
--- a/ServiceEssentials.xcodeproj/project.pbxproj
+++ b/ServiceEssentials.xcodeproj/project.pbxproj
@@ -730,7 +730,7 @@
 					"ALLOWS_TEST_ENVIRONMENTS=1",
 					"$(inherited)",
 				);
-				HEADER_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)/ServiceEssentials.framework/Headers";
+				HEADER_SEARCH_PATHS = "$(TARGET_BUILD_DIR)/$(PUBLIC_HEADERS_FOLDER_PATH)";
 				INFOPLIST_FILE = ServiceEssentials/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -751,7 +751,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_PREPROCESSOR_DEFINITIONS = "ALLOWS_TEST_ENVIRONMENTS=1";
-				HEADER_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)/ServiceEssentials.framework/Headers";
+				HEADER_SEARCH_PATHS = "$(TARGET_BUILD_DIR)/$(PUBLIC_HEADERS_FOLDER_PATH)/**";
 				INFOPLIST_FILE = ServiceEssentials/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -771,7 +771,10 @@
 					"$(PROJECT_DIR)/ServiceEssentialsTests/Frameworks/OCMock/iOS",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
-				HEADER_SEARCH_PATHS = "";
+				HEADER_SEARCH_PATHS = (
+					"$(TARGET_BUILD_DIR)/$(PUBLIC_HEADERS_FOLDER_PATH)",
+					"$(PROJECT_DIR)/**",
+				);
 				INFOPLIST_FILE = ServiceEssentialsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(FRAMEWORK_SEARCH_PATHS)";
 				OTHER_LDFLAGS = "-ObjC";
@@ -788,7 +791,10 @@
 					"$(PROJECT_DIR)/ServiceEssentialsTests/Frameworks/OCMock/iOS",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
-				HEADER_SEARCH_PATHS = "";
+				HEADER_SEARCH_PATHS = (
+					"$(TARGET_BUILD_DIR)/$(PUBLIC_HEADERS_FOLDER_PATH)",
+					"$(PROJECT_DIR)",
+				);
 				INFOPLIST_FILE = ServiceEssentialsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(FRAMEWORK_SEARCH_PATHS)";
 				OTHER_LDFLAGS = "-ObjC";

--- a/ServiceEssentials.xcodeproj/project.pbxproj
+++ b/ServiceEssentials.xcodeproj/project.pbxproj
@@ -730,6 +730,7 @@
 					"ALLOWS_TEST_ENVIRONMENTS=1",
 					"$(inherited)",
 				);
+				HEADER_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)/ServiceEssentials.framework/Headers";
 				INFOPLIST_FILE = ServiceEssentials/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -750,6 +751,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_PREPROCESSOR_DEFINITIONS = "ALLOWS_TEST_ENVIRONMENTS=1";
+				HEADER_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)/ServiceEssentials.framework/Headers";
 				INFOPLIST_FILE = ServiceEssentials/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;

--- a/ServiceEssentials.xcodeproj/project.pbxproj
+++ b/ServiceEssentials.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		D592AD441D90E9EC00108531 /* SEDataRequestFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = D592AD421D90E9EC00108531 /* SEDataRequestFactory.h */; };
 		D592AD451D90E9EC00108531 /* SEDataRequestFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = D592AD431D90E9EC00108531 /* SEDataRequestFactory.m */; };
 		D59737FB1D6A964400629740 /* SEDataRequestServiceUserAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = D59737FA1D6A957000629740 /* SEDataRequestServiceUserAgent.h */; };
+		D59A3B081DA754040089A344 /* SEDataRequestFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D59A3B071DA754040089A344 /* SEDataRequestFactoryTests.m */; };
 		D5A420E01D16ED5400471135 /* ServiceEssentials.h in Headers */ = {isa = PBXBuildFile; fileRef = D5A420DF1D16ED5400471135 /* ServiceEssentials.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D5A420F91D16EE4000471135 /* SEConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = D5A420F71D16EE4000471135 /* SEConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D5A420FA1D16EE4000471135 /* SEConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = D5A420F81D16EE4000471135 /* SEConstants.m */; };
@@ -100,6 +101,7 @@
 		D592AD421D90E9EC00108531 /* SEDataRequestFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SEDataRequestFactory.h; sourceTree = "<group>"; };
 		D592AD431D90E9EC00108531 /* SEDataRequestFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEDataRequestFactory.m; sourceTree = "<group>"; };
 		D59737FA1D6A957000629740 /* SEDataRequestServiceUserAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SEDataRequestServiceUserAgent.h; sourceTree = "<group>"; };
+		D59A3B071DA754040089A344 /* SEDataRequestFactoryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEDataRequestFactoryTests.m; sourceTree = "<group>"; };
 		D5A420DC1D16ED5400471135 /* ServiceEssentials.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ServiceEssentials.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5A420DF1D16ED5400471135 /* ServiceEssentials.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ServiceEssentials.h; sourceTree = "<group>"; };
 		D5A420E11D16ED5400471135 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -376,6 +378,7 @@
 				D5A421651D1783F200471135 /* SEMultipartRequestContentStreamTests.m */,
 				D5A421661D1783F200471135 /* SEPlainTextSerializerTests.m */,
 				D5A421671D1783F200471135 /* SEWebFormSerializerTests.m */,
+				D59A3B071DA754040089A344 /* SEDataRequestFactoryTests.m */,
 			);
 			path = DataRequestService;
 			sourceTree = "<group>";
@@ -600,6 +603,7 @@
 				D5A4216E1D1783F200471135 /* SEJSONSerializerTests.m in Sources */,
 				D5A421761D17874A00471135 /* SECancelableTokenTests.m in Sources */,
 				D5A421731D1783F200471135 /* SEPersistenceServiceTests.m in Sources */,
+				D59A3B081DA754040089A344 /* SEDataRequestFactoryTests.m in Sources */,
 				D5A421711D1783F200471135 /* SEWebFormSerializerTests.m in Sources */,
 				D5A4216B1D1783F200471135 /* SEDataRequestBuilderTests.m in Sources */,
 				D5A4216D1D1783F200471135 /* SEDataRequestServiceImplTests.m in Sources */,

--- a/ServiceEssentials/Constants/SEConstants.m
+++ b/ServiceEssentials/Constants/SEConstants.m
@@ -8,4 +8,4 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "SEConstants.h"
+#import <ServiceEssentials/SEConstants.h>

--- a/ServiceEssentials/Services/Cancellable/SECancellableTokenImpl.h
+++ b/ServiceEssentials/Services/Cancellable/SECancellableTokenImpl.h
@@ -10,7 +10,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "SECancellableToken.h"
+#import <ServiceEssentials/SECancellableToken.h>
 
 @interface SECancellableTokenImpl : NSObject<SECancellableToken>
 

--- a/ServiceEssentials/Services/Cancellable/SECancellableTokenImpl.m
+++ b/ServiceEssentials/Services/Cancellable/SECancellableTokenImpl.m
@@ -8,7 +8,7 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "SECancellableTokenImpl.h"
+#import <ServiceEssentials/SECancellableTokenImpl.h>
 
 @implementation SECancellableTokenImpl
 {

--- a/ServiceEssentials/Services/DataRequestService/SEDataRequestFactory.h
+++ b/ServiceEssentials/Services/DataRequestService/SEDataRequestFactory.h
@@ -9,8 +9,8 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "SEDataRequestService.h"
-#import "SEDataRequestServicePrivate.h"
+#import <ServiceEssentials/SEDataRequestService.h>
+#import <ServiceEssentials/SEDataRequestServicePrivate.h>
 
 @class SEInternalDataRequestBuilder;
 

--- a/ServiceEssentials/Services/DataRequestService/SEDataRequestFactory.h
+++ b/ServiceEssentials/Services/DataRequestService/SEDataRequestFactory.h
@@ -19,7 +19,7 @@
 - (nonnull instancetype)initWithService:(nonnull id<SEDataRequestServicePrivate>)service secure:(BOOL)secure userAgent:(nonnull NSString *)userAgent requestPreparationDelegate:(nullable id<SEDataRequestPreparationDelegate>)requestDelegate;
 
 @property (nonatomic, readonly, strong, nonnull) NSString *userAgent;
-@property (nonatomic, strong, nullable) NSString *authorizationHeader;
+@property (atomic, strong, nullable) NSString *authorizationHeader;
 
 - (nonnull NSURLRequest *)createRequestWithMethod:(nonnull NSString *)method
                                           baseURL:(nonnull NSURL *)baseURL

--- a/ServiceEssentials/Services/DataRequestService/SEDataRequestFactory.h
+++ b/ServiceEssentials/Services/DataRequestService/SEDataRequestFactory.h
@@ -10,7 +10,7 @@
 
 #import <Foundation/Foundation.h>
 #import <ServiceEssentials/SEDataRequestService.h>
-#import <ServiceEssentials/SEDataRequestServicePrivate.h>
+#import "SEDataRequestServicePrivate.h"
 
 @class SEInternalDataRequestBuilder;
 

--- a/ServiceEssentials/Services/DataRequestService/SEDataRequestFactory.m
+++ b/ServiceEssentials/Services/DataRequestService/SEDataRequestFactory.m
@@ -227,7 +227,7 @@ static inline BOOL SEDataRequestMethodURLEncodesBody(NSString *method)
                                   method:builder.method
                                  baseURL:baseURL
                                     path:builder.path
-                                    body:builder.bodyParameters
+                                    body:builder.bodyParameters ?: builder.body
                                 mimeType:builder.contentEncoding
                                  headers:builder.headers
                        acceptContentType:builder.acceptContentType
@@ -402,7 +402,12 @@ static inline BOOL SEDataRequestMethodURLEncodesBody(NSString *method)
     NSString *contentType = nil;
     BOOL isDictionary = [body isKindOfClass:[NSDictionary class]];
 
-    if (mimeType != nil)
+    if ([body isKindOfClass:[NSData class]])
+    {
+        data = body;
+        contentType = mimeType ?: SEDataRequestServiceContentTypeOctetStream;
+    }
+    else if (mimeType != nil)
     {
         NSError *serializationError = nil;
         SEDataSerializer *serializer = [_service explicitSerializerForMIMEType:mimeType];
@@ -455,11 +460,6 @@ static inline BOOL SEDataRequestMethodURLEncodesBody(NSString *method)
         }
 
         contentType = [NSString stringWithFormat:@"%@; charset=%@", SEDataRequestServiceContentTypeJSON, charset];
-    }
-    else if ([body isKindOfClass:[NSData class]])
-    {
-        data = body;
-        contentType = SEDataRequestServiceContentTypeOctetStream;
     }
     else
     {

--- a/ServiceEssentials/Services/DataRequestService/SEDataRequestFactory.m
+++ b/ServiceEssentials/Services/DataRequestService/SEDataRequestFactory.m
@@ -8,17 +8,17 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "SEDataRequestFactory.h"
+#import <ServiceEssentials/SEDataRequestFactory.h>
 
 #include <pthread.h>
 
-#import "SEDataRequestServicePrivate.h"
-#import "SEDataSerializer.h"
-#import "SEJSONDataSerializer.h"
-#import "SEInternalDataRequestBuilder.h"
-#import "SEMultipartRequestContentStream.h"
-#import "SETools.h"
-#import "SEWebFormSerializer.h"
+#import <ServiceEssentials/SEDataRequestServicePrivate.h>
+#import <ServiceEssentials/SEDataSerializer.h>
+#import <ServiceEssentials/SEJSONDataSerializer.h>
+#import <ServiceEssentials/SEInternalDataRequestBuilder.h>
+#import <ServiceEssentials/SEMultipartRequestContentStream.h>
+#import <ServiceEssentials/SETools.h>
+#import <ServiceEssentials/SEWebFormSerializer.h>
 
 #define CHECK_IF_SECURE do { if (!_isSecure) THROW_NOT_IMPLEMENTED((@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"%@ is not implemented for non-secure request factory", NSStringFromSelector(_cmd)] })); } while(0)
 

--- a/ServiceEssentials/Services/DataRequestService/SEDataRequestFactory.m
+++ b/ServiceEssentials/Services/DataRequestService/SEDataRequestFactory.m
@@ -422,7 +422,7 @@ static inline BOOL SEDataRequestMethodURLEncodesBody(NSString *method)
         {
             return SEDataRequestAssignSerializationError(serializationError, error);
         }
-        contentType = [NSString stringWithFormat:@"%@; charset=%@", mimeType, charset];
+        contentType = serializer.shouldAppendCharsetToContentType ? [NSString stringWithFormat:@"%@; charset=%@", mimeType, charset] : mimeType;
     }
     else if ([body isKindOfClass:[NSString class]])
     {

--- a/ServiceEssentials/Services/DataRequestService/SEDataRequestService.h
+++ b/ServiceEssentials/Services/DataRequestService/SEDataRequestService.h
@@ -95,7 +95,7 @@ typedef enum
 /** Set content encoding for data being sent */
 - (void) setContentEncoding: (nonnull NSString *) encoding;
 /** Sets an HTTP header for the request. Can be called multiple times. */
-- (void) setHTTPHeader: (nonnull NSString *) header forkey: (nonnull NSString *) key;
+- (void) setHTTPHeader: (nonnull NSString *) header forKey: (nonnull NSString *) key;
 /** Sets expected HTTP codes (as an index set). Defaults to 2xx. */
 - (void) setExpectedHTTPCodes: (nonnull NSIndexSet *) expectedCodes;
 

--- a/ServiceEssentials/Services/DataRequestService/SEDataRequestService.h
+++ b/ServiceEssentials/Services/DataRequestService/SEDataRequestService.h
@@ -99,8 +99,11 @@ typedef enum
 /** Sets expected HTTP codes (as an index set). Defaults to 2xx. */
 - (void) setExpectedHTTPCodes: (nonnull NSIndexSet *) expectedCodes;
 
-/** Set the request body parameters. Cannot be combined with multipart. */
+/** Set the request body parameters. Cannot be combined with data or multipart. */
 - (void) setBodyParameters: (nonnull NSDictionary<NSString *, id> *) parameters;
+
+/** Set the request body as raw data. Cannot be combined with parameters or multipart. */
+- (void) setBodyData:(nonnull NSData *) data;
 
 /** Request can be sent while application is in the background */
 - (void) setCanSendInBackground:(BOOL)canSendInBackground;

--- a/ServiceEssentials/Services/DataRequestService/SEDataRequestService.h
+++ b/ServiceEssentials/Services/DataRequestService/SEDataRequestService.h
@@ -13,9 +13,9 @@
 
 @import Foundation;
 
-#import "SEConstants.h"
-#import "SECancellableToken.h"
-#import "SEDataRequestJSONDeserializable.h"
+#import <ServiceEssentials/SEConstants.h>
+#import <ServiceEssentials/SECancellableToken.h>
+#import <ServiceEssentials/SEDataRequestJSONDeserializable.h>
 
 extern NSString * _Nonnull const SEDataRequestServiceChangedReachabilityNotification;
 extern NSString * _Nonnull const SEDataRequestServiceChangedReachabilityStatusKey;

--- a/ServiceEssentials/Services/DataRequestService/SEDataRequestServiceImpl.h
+++ b/ServiceEssentials/Services/DataRequestService/SEDataRequestServiceImpl.h
@@ -8,7 +8,7 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "SEDataRequestService.h"
+#import <ServiceEssentials/SEDataRequestService.h>
 
 @protocol SEEnvironmentService;
 @class SEDataSerializer;

--- a/ServiceEssentials/Services/DataRequestService/SEDataRequestServiceImpl.m
+++ b/ServiceEssentials/Services/DataRequestService/SEDataRequestServiceImpl.m
@@ -8,8 +8,8 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "SEDataRequestServiceImpl.h"
-#import "SEDataRequestServicePrivate.h"
+#import <ServiceEssentials/SEDataRequestServiceImpl.h>
+#import <ServiceEssentials/SEDataRequestServicePrivate.h>
 
 #include <pthread.h>
 #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)

--- a/ServiceEssentials/Services/DataRequestService/SEDataRequestServicePrivate.h
+++ b/ServiceEssentials/Services/DataRequestService/SEDataRequestServicePrivate.h
@@ -21,8 +21,8 @@ typedef enum {
 #include <objc/runtime.h>
 
 #import <ServiceEssentials/SEDataRequestServiceImpl.h>
-#import <ServiceEssentials/SETools.h>
 #import <ServiceEssentials/SEWebFormSerializer.h>
+#import "SETools.h"
 
 extern NSString * _Nonnull const SEDataRequestMethodGET;
 extern NSString * _Nonnull const SEDataRequestMethodPOST;

--- a/ServiceEssentials/Services/DataRequestService/SEDataRequestServicePrivate.h
+++ b/ServiceEssentials/Services/DataRequestService/SEDataRequestServicePrivate.h
@@ -20,9 +20,9 @@ typedef enum {
 
 #include <objc/runtime.h>
 
-#import "SEDataRequestServiceImpl.h"
-#import "SETools.h"
-#import "SEWebFormSerializer.h"
+#import <ServiceEssentials/SEDataRequestServiceImpl.h>
+#import <ServiceEssentials/SETools.h>
+#import <ServiceEssentials/SEWebFormSerializer.h>
 
 extern NSString * _Nonnull const SEDataRequestMethodGET;
 extern NSString * _Nonnull const SEDataRequestMethodPOST;

--- a/ServiceEssentials/Services/DataRequestService/SEDataRequestServiceSecurityHelper.m
+++ b/ServiceEssentials/Services/DataRequestService/SEDataRequestServiceSecurityHelper.m
@@ -33,9 +33,9 @@
 // -----------------------------------------------------------------------------
 
 
-#import "SEDataRequestServiceSecurityHelper.h"
+#import <ServiceEssentials/SEDataRequestServiceSecurityHelper.h>
 
-#import "SEDataRequestService.h"
+#import <ServiceEssentials/SEDataRequestService.h>
 
 // Declarations for some helper functions
 #if !defined(__IPHONE_OS_VERSION_MIN_REQUIRED)

--- a/ServiceEssentials/Services/DataRequestService/SEInternalDataRequest.h
+++ b/ServiceEssentials/Services/DataRequestService/SEInternalDataRequest.h
@@ -9,7 +9,7 @@
 //
 
 @import Foundation;
-#import "SEDataRequestService.h"
+#import <ServiceEssentials/SEDataRequestService.h>
 
 @protocol SEDataRequestServicePrivate;
 @protocol SECancellableToken;

--- a/ServiceEssentials/Services/DataRequestService/SEInternalDataRequest.m
+++ b/ServiceEssentials/Services/DataRequestService/SEInternalDataRequest.m
@@ -8,17 +8,17 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "SEInternalDataRequest.h"
+#import <ServiceEssentials/SEInternalDataRequest.h>
 
 #include <objc/runtime.h>
 #include <libkern/OSAtomic.h>
 
-#import "SETools.h"
-#import "SEDataRequestService.h"
-#import "SEDataRequestServicePrivate.h"
-#import "SEDataSerializer.h"
-#import "SECancellableTokenImpl.h"
-#import "SEMultipartRequestContentStream.h"
+#import <ServiceEssentials/SETools.h>
+#import <ServiceEssentials/SEDataRequestService.h>
+#import <ServiceEssentials/SEDataRequestServicePrivate.h>
+#import <ServiceEssentials/SEDataSerializer.h>
+#import <ServiceEssentials/SECancellableTokenImpl.h>
+#import <ServiceEssentials/SEMultipartRequestContentStream.h>
 
 #define COMPLETED_REQUEST_BIT       0 // signals that request has been completed
 #define CANCELLED_REQUEST_BIT       1 // signals that request has been cancelled, this bit will also be set by completed callback

--- a/ServiceEssentials/Services/DataRequestService/SEInternalDataRequestBuilder.h
+++ b/ServiceEssentials/Services/DataRequestService/SEInternalDataRequestBuilder.h
@@ -30,6 +30,7 @@
 @property (nonatomic, readonly, strong, nullable) NSDictionary<NSString *, NSString *> *headers;
 @property (nonatomic, readonly, strong, nullable) NSIndexSet *expectedHTTPCodes;
 @property (nonatomic, readonly, strong, nullable) NSDictionary<NSString *, id> *bodyParameters;
+@property (nonatomic, readonly, strong, nullable) NSData *body;
 @property (nonatomic, readonly, strong, nullable) NSArray<SEMultipartRequestContentPart *> *contentParts;
 @property (nonatomic, readonly, strong, nullable) NSNumber *canSendInBackground;
 

--- a/ServiceEssentials/Services/DataRequestService/SEInternalDataRequestBuilder.h
+++ b/ServiceEssentials/Services/DataRequestService/SEInternalDataRequestBuilder.h
@@ -8,8 +8,8 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "SEDataRequestService.h"
-#import "SEDataRequestServicePrivate.h"
+#import <ServiceEssentials/SEDataRequestService.h>
+#import <ServiceEssentials/SEDataRequestServicePrivate.h>
 
 @class SEMultipartRequestContentPart;
 

--- a/ServiceEssentials/Services/DataRequestService/SEInternalDataRequestBuilder.h
+++ b/ServiceEssentials/Services/DataRequestService/SEInternalDataRequestBuilder.h
@@ -9,7 +9,7 @@
 //
 
 #import <ServiceEssentials/SEDataRequestService.h>
-#import <ServiceEssentials/SEDataRequestServicePrivate.h>
+#import "SEDataRequestServicePrivate.h"
 
 @class SEMultipartRequestContentPart;
 

--- a/ServiceEssentials/Services/DataRequestService/SEInternalDataRequestBuilder.m
+++ b/ServiceEssentials/Services/DataRequestService/SEInternalDataRequestBuilder.m
@@ -137,12 +137,22 @@
 
 - (void)setBodyParameters:(NSDictionary<NSString *,id> *)parameters
 {
-    if (_bodyParameters != nil || _contentParts != nil)
+    if (_bodyParameters != nil || _body != nil || _contentParts != nil)
     {
         THROW_INCONSISTENCY(@{ NSLocalizedDescriptionKey: @"Cannot set body paramters at this stage." });
     }
 
     _bodyParameters = [parameters copy];
+}
+
+- (void)setBodyData:(NSData *)data
+{
+    if (_bodyParameters != nil || _body != nil || _contentParts != nil)
+    {
+        THROW_INCONSISTENCY(@{ NSLocalizedDescriptionKey: @"Cannot set body at this stage." });
+    }
+
+    _body = [data copy];
 }
 
 - (void)setCanSendInBackground:(BOOL)canSendInBackground
@@ -152,7 +162,7 @@
 
 - (BOOL)checkMultipartRequestPossibleOrError: (NSError * _Nullable __autoreleasing *)error
 {
-    if (_bodyParameters != nil || _contentEncoding != nil)
+    if (_bodyParameters != nil || _body != nil || _contentEncoding != nil)
     {
         NSDictionary *info = @{ NSLocalizedDescriptionKey: @"Cannot add multipart content to a request that has body or custom content type." };
         if (error != nil) *error = [NSError errorWithDomain:SEErrorDomain code:SEDataRequestServiceRequestBuilderFailure userInfo:info];

--- a/ServiceEssentials/Services/DataRequestService/SEInternalDataRequestBuilder.m
+++ b/ServiceEssentials/Services/DataRequestService/SEInternalDataRequestBuilder.m
@@ -8,7 +8,7 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "SEInternalDataRequestBuilder.h"
+#import <ServiceEssentials/SEInternalDataRequestBuilder.h>
 
 #import "SETools.h"
 #import "SEMultipartRequestContentPart.h"

--- a/ServiceEssentials/Services/DataRequestService/SEInternalDataRequestBuilder.m
+++ b/ServiceEssentials/Services/DataRequestService/SEInternalDataRequestBuilder.m
@@ -116,7 +116,7 @@
     _contentEncoding = encoding;
 }
 
-- (void)setHTTPHeader:(NSString *)header forkey:(NSString *)key
+- (void)setHTTPHeader:(NSString *)header forKey:(NSString *)key
 {
     if (header == nil) THROW_INVALID_PARAM(header, nil);
     if (key == nil) THROW_INVALID_PARAM(key, nil);

--- a/ServiceEssentials/Services/DataRequestService/SEInternalDataRequestBuilder.m
+++ b/ServiceEssentials/Services/DataRequestService/SEInternalDataRequestBuilder.m
@@ -108,7 +108,7 @@
 
 - (void)setContentEncoding:(NSString *)encoding
 {
-    if (_contentParts != nil || [_dataRequestService explicitSerializerForMIMEType:encoding] == nil)
+    if (_contentParts != nil || (_bodyParameters != nil && [_dataRequestService explicitSerializerForMIMEType:encoding] == nil))
     {
         INVALID_BUILDER_PARAM(encoding);
     }
@@ -137,7 +137,7 @@
 
 - (void)setBodyParameters:(NSDictionary<NSString *,id> *)parameters
 {
-    if (_bodyParameters != nil || _body != nil || _contentParts != nil)
+    if (_bodyParameters != nil || _body != nil || _contentParts != nil || (_contentEncoding != nil && [_dataRequestService explicitSerializerForMIMEType:_contentEncoding] == nil))
     {
         THROW_INCONSISTENCY(@{ NSLocalizedDescriptionKey: @"Cannot set body paramters at this stage." });
     }

--- a/ServiceEssentials/Services/DataRequestService/SEMultipartRequestContentPart.m
+++ b/ServiceEssentials/Services/DataRequestService/SEMultipartRequestContentPart.m
@@ -8,7 +8,7 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "SEMultipartRequestContentPart.h"
+#import <ServiceEssentials/SEMultipartRequestContentPart.h>
 
 @implementation SEMultipartRequestContentPart
 {

--- a/ServiceEssentials/Services/DataRequestService/SEMultipartRequestContentStream.m
+++ b/ServiceEssentials/Services/DataRequestService/SEMultipartRequestContentStream.m
@@ -8,11 +8,11 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "SEMultipartRequestContentStream.h"
+#import <ServiceEssentials/SEMultipartRequestContentStream.h>
 
 #include <pthread.h>
-#import "SETools.h"
-#import "SEMultipartRequestContentPart.h"
+#import <ServiceEssentials/SETools.h>
+#import <ServiceEssentials/SEMultipartRequestContentPart.h>
 
 static NSString *const SEMultipartStreamContentCRLF = @"\r\n";
 

--- a/ServiceEssentials/Services/DataRequestService/SENetworkReachabilityTracker.h
+++ b/ServiceEssentials/Services/DataRequestService/SENetworkReachabilityTracker.h
@@ -8,7 +8,7 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "SEDataRequestService.h"
+#import <ServiceEssentials/SEDataRequestService.h>
 
 @class SENetworkReachabilityTracker;
 

--- a/ServiceEssentials/Services/DataRequestService/SENetworkReachabilityTracker.m
+++ b/ServiceEssentials/Services/DataRequestService/SENetworkReachabilityTracker.m
@@ -8,8 +8,8 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "SENetworkReachabilityTracker.h"
-#import "SETools.h"
+#import <ServiceEssentials/SENetworkReachabilityTracker.h>
+#import <ServiceEssentials/SETools.h>
 
 // Remove the header to disable the notifications.
 @import SystemConfiguration;

--- a/ServiceEssentials/Services/DataRequestService/Serializers/SEDataSerializer.h
+++ b/ServiceEssentials/Services/DataRequestService/Serializers/SEDataSerializer.h
@@ -19,6 +19,11 @@
  */
 @property (nonatomic, readonly) BOOL supportsAdditionalParameters;
 
+/**
+ Determines if `Content-Type` header should contain charset when using this serializer
+ */
+@property (nonatomic, readonly) BOOL shouldAppendCharsetToContentType;
+
 /** Serialize the object to data
  @param object object to be serialized
  @param mimeType data type hint, seializers could use it to extract charset and other encoding parameters

--- a/ServiceEssentials/Services/DataRequestService/Serializers/SEDataSerializer.m
+++ b/ServiceEssentials/Services/DataRequestService/Serializers/SEDataSerializer.m
@@ -8,11 +8,11 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "SEDataSerializer.h"
+#import <ServiceEssentials/SEDataSerializer.h>
 
 @import MobileCoreServices;
 
-#import "SEDataRequestService.h"
+#import <ServiceEssentials/SEDataRequestService.h>
 
 @implementation SEDataSerializer
 

--- a/ServiceEssentials/Services/DataRequestService/Serializers/SEDataSerializer.m
+++ b/ServiceEssentials/Services/DataRequestService/Serializers/SEDataSerializer.m
@@ -21,6 +21,11 @@
     return NO;
 }
 
+- (BOOL)shouldAppendCharsetToContentType
+{
+    return NO;
+}
+
 - (NSData *)serializeObject:(id)object mimeType:(NSString *)mimeType error:(NSError *__autoreleasing *)error
 {
     if ([object isKindOfClass:[NSData class]])

--- a/ServiceEssentials/Services/DataRequestService/Serializers/SEJSONDataSerializer.h
+++ b/ServiceEssentials/Services/DataRequestService/Serializers/SEJSONDataSerializer.h
@@ -9,7 +9,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "SEDataSerializer.h"
+#import <ServiceEssentials/SEDataSerializer.h>
 
 @interface SEJSONDataSerializer : SEDataSerializer
 

--- a/ServiceEssentials/Services/DataRequestService/Serializers/SEJSONDataSerializer.m
+++ b/ServiceEssentials/Services/DataRequestService/Serializers/SEJSONDataSerializer.m
@@ -41,6 +41,11 @@ static NSData *_SerializeJSON(id object, NSError *__autoreleasing *error)
     return YES;
 }
 
+- (BOOL)shouldAppendCharsetToContentType
+{
+    return YES;
+}
+
 - (NSData *)serializeObject:(id)object mimeType:(NSString *)mimeType error:(NSError *__autoreleasing *)error
 {
     return _SerializeJSON(object, error);

--- a/ServiceEssentials/Services/DataRequestService/Serializers/SEJSONDataSerializer.m
+++ b/ServiceEssentials/Services/DataRequestService/Serializers/SEJSONDataSerializer.m
@@ -8,8 +8,8 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "SEJSONDataSerializer.h"
-#import "SEDataRequestService.h"
+#import <ServiceEssentials/SEJSONDataSerializer.h>
+#import <ServiceEssentials/SEDataRequestService.h>
 
 static NSData *_SerializeJSON(id object, NSError *__autoreleasing *error)
 {

--- a/ServiceEssentials/Services/DataRequestService/Serializers/SEPlainTextSerializer.h
+++ b/ServiceEssentials/Services/DataRequestService/Serializers/SEPlainTextSerializer.h
@@ -9,7 +9,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "SEDataSerializer.h"
+#import <ServiceEssentials/SEDataSerializer.h>
 
 @interface SEPlainTextSerializer : SEDataSerializer
 

--- a/ServiceEssentials/Services/DataRequestService/Serializers/SEPlainTextSerializer.m
+++ b/ServiceEssentials/Services/DataRequestService/Serializers/SEPlainTextSerializer.m
@@ -33,6 +33,11 @@
     return [string dataUsingEncoding:encoding];
 }
 
+- (BOOL)shouldAppendCharsetToContentType
+{
+    return YES;
+}
+
 - (id)deserializeData:(NSData *)data mimeType:(NSString *)mimeType error:(NSError *__autoreleasing *)error
 {
     NSStringEncoding encoding = [SEDataSerializer charsetFromMIMEType:mimeType];

--- a/ServiceEssentials/Services/DataRequestService/Serializers/SEPlainTextSerializer.m
+++ b/ServiceEssentials/Services/DataRequestService/Serializers/SEPlainTextSerializer.m
@@ -8,8 +8,8 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "SEPlainTextSerializer.h"
-#import "SEDataRequestService.h"
+#import <ServiceEssentials/SEPlainTextSerializer.h>
+#import <ServiceEssentials/SEDataRequestService.h>
 
 @implementation SEPlainTextSerializer
 

--- a/ServiceEssentials/Services/DataRequestService/Serializers/SEWebFormSerializer.h
+++ b/ServiceEssentials/Services/DataRequestService/Serializers/SEWebFormSerializer.h
@@ -8,7 +8,7 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "SEDataSerializer.h"
+#import <ServiceEssentials/SEDataSerializer.h>
 
 @interface SEWebFormSerializer : SEDataSerializer
 

--- a/ServiceEssentials/Services/DataRequestService/Serializers/SEWebFormSerializer.m
+++ b/ServiceEssentials/Services/DataRequestService/Serializers/SEWebFormSerializer.m
@@ -6,9 +6,9 @@
 //  Copyright (c) 2015 AlphaNgen. All rights reserved.
 //
 
-#import "SEWebFormSerializer.h"
+#import <ServiceEssentials/SEWebFormSerializer.h>
 
-#import "SEDataRequestService.h"
+#import <ServiceEssentials/SEDataRequestService.h>
 
 static inline NSString * PercentEscapedQueryString(NSString *string, CFStringRef exceptCharacters, NSStringEncoding encoding)
 {

--- a/ServiceEssentials/Services/DataRequestService/Serializers/SEWebFormSerializer.m
+++ b/ServiceEssentials/Services/DataRequestService/Serializers/SEWebFormSerializer.m
@@ -47,6 +47,11 @@ static inline void AppendQueryComponent(NSMutableString *mutableString, NSString
     return YES;
 }
 
+- (BOOL)shouldAppendCharsetToContentType
+{
+    return YES;
+}
+
 - (NSData *)serializeObject:(id)object mimeType:(NSString *)mimeType error:(NSError *__autoreleasing *)error
 {
     if (![object isKindOfClass:[NSDictionary class]])

--- a/ServiceEssentials/Services/PersistenceService/SEFetchParameters.m
+++ b/ServiceEssentials/Services/PersistenceService/SEFetchParameters.m
@@ -8,7 +8,7 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "SEFetchParameters.h"
+#import <ServiceEssentials/SEFetchParameters.h>
 
 @implementation SEFetchParameters
 

--- a/ServiceEssentials/Services/PersistenceService/SEPersistenceService.h
+++ b/ServiceEssentials/Services/PersistenceService/SEPersistenceService.h
@@ -9,7 +9,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "SEFetchParameters.h"
+#import <ServiceEssentials/SEFetchParameters.h>
 
 @class NSManagedObjectContext;
 @class NSManagedObjectModel;

--- a/ServiceEssentials/Services/PersistenceService/SEPersistenceService.m
+++ b/ServiceEssentials/Services/PersistenceService/SEPersistenceService.m
@@ -13,9 +13,9 @@
 #include <libkern/OSAtomic.h>
 #import <CoreData/CoreData.h>
 
-#import "SETools.h"
-#import "SEConstants.h"
-#import "NSArray+SEJSONExtensions.h"
+#import <ServiceEssentials/SETools.h>
+#import <ServiceEssentials/SEConstants.h>
+#import <ServiceEssentials/NSArray+SEJSONExtensions.h>
 
 NSString * _Nonnull const SEPersistenceServiceInitializationCompleteNotification = @"SEPersistenceServiceInitializationCompleteNotification";
 NSString * _Nonnull const SEPersistenceServiceInitializationSucceededKey = @"SEPersistenceServiceInitializationSucceededKey";

--- a/ServiceEssentials/Services/ServiceLocation/SEServiceLocator.m
+++ b/ServiceEssentials/Services/ServiceLocation/SEServiceLocator.m
@@ -8,11 +8,11 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "SEServiceLocator.h"
+#import <ServiceEssentials/SEServiceLocator.h>
 
 #import <pthread.h>
-#import "SETools.h"
-#import "SEServiceWeakProxy.h"
+#import <ServiceEssentials/SETools.h>
+#import <ServiceEssentials/SEServiceWeakProxy.h>
 
 @interface SEServiceContainer : NSObject
 - (instancetype) initWithObject: (id) object;

--- a/ServiceEssentials/Services/ServiceLocation/SEServiceWeakProxy.m
+++ b/ServiceEssentials/Services/ServiceLocation/SEServiceWeakProxy.m
@@ -8,8 +8,8 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "SEServiceWeakProxy.h"
-#import "SETools.h"
+#import <ServiceEssentials/SEServiceWeakProxy.h>
+#import <ServiceEssentials/SETools.h>
 #include <objc/runtime.h>
 
 @implementation SEServiceWeakProxy

--- a/ServiceEssentials/Tools/NSArray+JSONExtensions.m
+++ b/ServiceEssentials/Tools/NSArray+JSONExtensions.m
@@ -8,8 +8,8 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "NSArray+SEJSONExtensions.h"
-#import "SETools.h"
+#import <ServiceEssentials/NSArray+SEJSONExtensions.h>
+#import <ServiceEssentials/SETools.h>
 
 @implementation NSArray (SEJSONExtensions)
 

--- a/ServiceEssentials/Tools/NSDictionary+SEJSONExtensions.m
+++ b/ServiceEssentials/Tools/NSDictionary+SEJSONExtensions.m
@@ -8,8 +8,8 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "NSDictionary+SEJSONExtensions.h"
-#import "NSArray+SEJSONExtensions.h"
+#import <ServiceEssentials/NSDictionary+SEJSONExtensions.h>
+#import <ServiceEssentials/NSArray+SEJSONExtensions.h>
 
 @implementation NSDictionary (SEJSONExtensions)
 

--- a/ServiceEssentials/Tools/NSString+SEExtensions.m
+++ b/ServiceEssentials/Tools/NSString+SEExtensions.m
@@ -8,7 +8,7 @@
 //  Distributed under BSD license. See LICENSE for details.
 //
 
-#import "NSString+SEExtensions.h"
+#import <ServiceEssentials/NSString+SEExtensions.h>
 
 @implementation NSString(SEExtentsions)
 

--- a/ServiceEssentialsTests/Services/DataRequestService/SEDataRequestBuilderTests.m
+++ b/ServiceEssentialsTests/Services/DataRequestService/SEDataRequestBuilderTests.m
@@ -315,8 +315,8 @@
     static NSString *const SecondHeaderValue = @"OtherHeaderValue";
 
     id<SEDataRequestCustomizer> customizer = [self createSimpleBuilderAndPost];
-    [customizer setHTTPHeader:FirstHeaderValue forkey:FirstHeader];
-    [customizer setHTTPHeader:SecondHeaderValue forkey:SecondHeader];
+    [customizer setHTTPHeader:FirstHeaderValue forKey:FirstHeader];
+    [customizer setHTTPHeader:SecondHeaderValue forKey:SecondHeader];
     
     SEInternalDataRequestBuilder *builder = (SEInternalDataRequestBuilder *)customizer;
     NSDictionary *headers = builder.headers;

--- a/ServiceEssentialsTests/Services/DataRequestService/SEDataRequestBuilderTests.m
+++ b/ServiceEssentialsTests/Services/DataRequestService/SEDataRequestBuilderTests.m
@@ -138,7 +138,7 @@
     OCMVerifyAll(self.dataRequestServiceMock);
 }
 
-- (void)testAdditionalRequestConfigurationBody
+- (void)testAdditionalRequestConfigurationBodyParameters
 {
     NSString * const path = @"some/my/path";
     
@@ -161,11 +161,44 @@
     XCTAssertEqual(failure, builder.failure);
     XCTAssertEqual(queue, builder.completionQueue);
     XCTAssertEqualObjects(bodyParameters, builder.bodyParameters);
+    XCTAssertNil(builder.body);
     XCTAssertNil(builder.contentEncoding);
     XCTAssertNil(builder.contentParts);
     XCTAssertNil(builder.deserializeClass);
     XCTAssertNil(builder.headers);
     
+    OCMVerifyAll(self.dataRequestServiceMock);
+}
+
+- (void)testAdditionalRequestConfigurationBody
+{
+    NSString * const path = @"some/my/path";
+
+    void (^success)(id data, NSURLResponse *response) = ^(id data, NSURLResponse *response){ };
+    void (^failure)(NSError *error) = ^(NSError *error){ };
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    NSData *const body = [@"some data here" dataUsingEncoding:NSUTF8StringEncoding];
+
+    SEInternalDataRequestBuilder *builder = [[SEInternalDataRequestBuilder alloc] initWithDataRequestService:self.dataRequestServiceMock];
+
+    id<SEDataRequestCustomizer> customizer = [builder POST:path success:success failure:failure completionQueue:queue];
+
+    [customizer setBodyData:body];
+
+    XCTAssertNotNil(customizer);
+    XCTAssertEqualObjects(@"POST", builder.method);
+    XCTAssertEqualObjects(path, builder.path);
+    XCTAssertEqual(success, builder.success);
+    XCTAssertEqual(failure, builder.failure);
+    XCTAssertEqual(queue, builder.completionQueue);
+    XCTAssertEqualObjects(body, builder.body);
+    XCTAssertNil(builder.bodyParameters);
+    XCTAssertNil(builder.contentEncoding);
+    XCTAssertNil(builder.contentParts);
+    XCTAssertNil(builder.deserializeClass);
+    XCTAssertNil(builder.headers);
+
     OCMVerifyAll(self.dataRequestServiceMock);
 }
 

--- a/ServiceEssentialsTests/Services/DataRequestService/SEDataRequestFactoryTests.m
+++ b/ServiceEssentialsTests/Services/DataRequestService/SEDataRequestFactoryTests.m
@@ -13,6 +13,12 @@
 #import "SEDataRequestFactory.h"
 #import "SEInternalDataRequestBuilder.h"
 
+static NSString *const MethodGET = @"GET";
+static NSString *const MethodPOST = @"POST";
+static NSString *const MethodPUT = @"PUT";
+static NSString *const MethodHEAD = @"HEAD";
+
+
 @interface SEDataRequestFactoryTests : XCTestCase
 
 @end
@@ -31,6 +37,7 @@
     [super setUp];
     
     _serviceMock = [OCMockObject mockForProtocol:@protocol(SEDataRequestServicePrivate)];
+    [[[_serviceMock stub] andReturnValue:@(NSUTF8StringEncoding)] stringEncoding];
     _preparationDelegateMock = [OCMockObject mockForProtocol:@protocol(SEDataRequestPreparationDelegate)];
     _userAgentString = @"Mock user agent";
     _baseURL = [NSURL URLWithString:@"https://service.essentials.com"];
@@ -44,9 +51,15 @@
     _preparationDelegateMock = nil;
 }
 
+- (void)veriyAllMocks
+{
+    [_serviceMock verify];
+    [_preparationDelegateMock verify];
+}
+
 - (void)testRequestFactoryThrowsOnUnsafeFactoryCreatingRequestsRequiringSecure
 {
-    SEDataRequestFactory *factory = [[SEDataRequestFactory alloc] initWithService:_serviceMock secure:YES userAgent:_userAgentString requestPreparationDelegate:_preparationDelegateMock];
+    SEDataRequestFactory *factory = [[SEDataRequestFactory alloc] initWithService:_serviceMock secure:NO userAgent:_userAgentString requestPreparationDelegate:nil];
     
     NSError *error = nil;
     XCTAssertThrows([factory createRequestWithMethod:@"GET" baseURL:_baseURL path:@"my_path/method" body:nil mimeType:nil error:&error]);
@@ -57,6 +70,92 @@
     XCTAssertThrows([factory createRequestWithBuilder:builder baseURL:_baseURL error:&error]);
 
     XCTAssertThrows([factory createMultipartRequestWithBuilder:builder baseURL:_baseURL boundary:@"boundary" error:&error]);
+
+    [self veriyAllMocks];
 }
+
+- (void)testRequestFactoryThrowsOnUnsafeFactoryCreatingRequestsRequiringUnsafe
+{
+    SEDataRequestFactory *factory = [[SEDataRequestFactory alloc] initWithService:_serviceMock secure:YES userAgent:_userAgentString requestPreparationDelegate:_preparationDelegateMock];
+
+    NSError *error = nil;
+    XCTAssertThrows([factory createUnsafeRequestWithMethod:@"GET" URL:_baseURL parameters:nil mimeType:nil error:&error]);
+
+    [self veriyAllMocks];
+}
+
+- (void)testRequestFactoryCreateRequestWithoutBodyNoDelegate
+{
+    NSString *const path = @"some-path";
+    SEDataRequestFactory *factory = [[SEDataRequestFactory alloc] initWithService:_serviceMock secure:YES userAgent:_userAgentString requestPreparationDelegate:nil];
+
+    NSError *error = nil;
+    NSURLRequest *request = [factory createRequestWithMethod:MethodGET baseURL:_baseURL path:path body:nil mimeType:nil error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(request);
+
+    XCTAssertEqualObjects(request.URL, [NSURL URLWithString:path relativeToURL:_baseURL]);
+    XCTAssertEqualObjects(request.HTTPMethod, MethodGET);
+    XCTAssertNil(request.HTTPBody);
+
+    NSDictionary<NSString *, NSString *> *expectedHeaders = @{
+                                                              @"User-Agent" : _userAgentString,
+                                                              @"Accept" : @"application/json; charset=utf-8"
+                                                              };
+    XCTAssertEqualObjects(request.allHTTPHeaderFields, expectedHeaders);
+
+    [self veriyAllMocks];
+}
+
+- (void)testRequestFactoryCreateGETRequestConvertsBodyToURLQuery
+{
+    NSString *const path = @"other-path";
+    NSDictionary *const parameters = @{ @"first" : @"value", @"second" : @2 };
+    SEDataRequestFactory *factory = [[SEDataRequestFactory alloc] initWithService:_serviceMock secure:YES userAgent:_userAgentString requestPreparationDelegate:nil];
+
+    NSError *error = nil;
+    NSURLRequest *request = [factory createRequestWithMethod:MethodGET baseURL:_baseURL path:path body:parameters mimeType:nil error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(request);
+
+    NSURL *expectedURL = [NSURL URLWithString:@"other-path?first=value&second=2" relativeToURL:_baseURL];
+    XCTAssertEqualObjects(request.URL, expectedURL);
+    XCTAssertEqualObjects(request.HTTPMethod, MethodGET);
+    XCTAssertNil(request.HTTPBody);
+
+    NSDictionary<NSString *, NSString *> *expectedHeaders = @{
+                                                              @"User-Agent" : _userAgentString,
+                                                              @"Accept" : @"application/json; charset=utf-8"
+                                                              };
+    XCTAssertEqualObjects(request.allHTTPHeaderFields, expectedHeaders);
+
+    [self veriyAllMocks];
+}
+
+- (void)testRequestFactoryCreateUnsafeRequestWithoutBody
+{
+    NSURL *url = [_baseURL URLByAppendingPathComponent:@"some-other-path"];
+    SEDataRequestFactory *factory = [[SEDataRequestFactory alloc] initWithService:_serviceMock secure:NO userAgent:_userAgentString requestPreparationDelegate:nil];
+
+    NSError *error = nil;
+    NSURLRequest *request = [factory createUnsafeRequestWithMethod:MethodGET URL:url parameters:nil mimeType:nil error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(request);
+
+    XCTAssertEqualObjects(request.URL, url);
+    XCTAssertEqualObjects(request.HTTPMethod, MethodGET);
+    XCTAssertNil(request.HTTPBody);
+
+    NSDictionary<NSString *, NSString *> *expectedHeaders = @{
+                                                              @"User-Agent" : _userAgentString,
+                                                              };
+    XCTAssertEqualObjects(request.allHTTPHeaderFields, expectedHeaders);
+
+    [self veriyAllMocks];
+}
+
 
 @end

--- a/ServiceEssentialsTests/Services/DataRequestService/SEDataRequestFactoryTests.m
+++ b/ServiceEssentialsTests/Services/DataRequestService/SEDataRequestFactoryTests.m
@@ -1,0 +1,54 @@
+//
+//  SEDataRequestFactoryTests.m
+//  Service Essentials
+//
+//  Created by Anton Vaneev.
+//  Copyright (c) 2015 Anton Vaneev. All rights reserved.
+//
+//  Distributed under BSD license. See LICENSE for details.
+//
+
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import "SEDataRequestFactory.h"
+
+@interface SEDataRequestFactoryTests : XCTestCase
+
+@end
+
+@implementation SEDataRequestFactoryTests
+{
+    OCMockObject<SEDataRequestServicePrivate> *_serviceMock;
+    OCMockObject<SEDataRequestPreparationDelegate> *_preparationDelegateMock;
+    
+    NSString *_userAgentString;
+    NSURL *_baseURL;
+}
+
+- (void)setUp
+{
+    [super setUp];
+    
+    _serviceMock = [OCMockObject mockForProtocol:@protocol(SEDataRequestServicePrivate)];
+    _preparationDelegateMock = [OCMockObject mockForProtocol:@protocol(SEDataRequestPreparationDelegate)];
+    _userAgentString = @"Mock user agent";
+    _baseURL = [NSURL URLWithString:@"https://service.essentials.com"];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+    
+    _serviceMock = nil;
+    _preparationDelegateMock = nil;
+}
+
+- (void)testRequestFactoryThrowsOnUnsafeFactoryCreatingSimpleRequest
+{
+    SEDataRequestFactory *factory = [[SEDataRequestFactory alloc] initWithService:_serviceMock secure:YES userAgent:_userAgentString requestPreparationDelegate:_preparationDelegateMock];
+    
+    NSError *error = nil;
+    XCTAssertThrows([factory createRequestWithMethod:@"GET" baseURL:_baseURL path:@"my_path/method" body:nil mimeType:nil error:&error]);
+}
+
+@end

--- a/ServiceEssentialsTests/Services/DataRequestService/SEDataRequestFactoryTests.m
+++ b/ServiceEssentialsTests/Services/DataRequestService/SEDataRequestFactoryTests.m
@@ -11,6 +11,7 @@
 #import <XCTest/XCTest.h>
 #import <OCMock/OCMock.h>
 #import "SEDataRequestFactory.h"
+#import "SEInternalDataRequestBuilder.h"
 
 @interface SEDataRequestFactoryTests : XCTestCase
 
@@ -43,12 +44,19 @@
     _preparationDelegateMock = nil;
 }
 
-- (void)testRequestFactoryThrowsOnUnsafeFactoryCreatingSimpleRequest
+- (void)testRequestFactoryThrowsOnUnsafeFactoryCreatingRequestsRequiringSecure
 {
     SEDataRequestFactory *factory = [[SEDataRequestFactory alloc] initWithService:_serviceMock secure:YES userAgent:_userAgentString requestPreparationDelegate:_preparationDelegateMock];
     
     NSError *error = nil;
     XCTAssertThrows([factory createRequestWithMethod:@"GET" baseURL:_baseURL path:@"my_path/method" body:nil mimeType:nil error:&error]);
+
+    XCTAssertThrows([factory createDownloadRequestWithBaseURL:_baseURL path:@"path" body:nil error:&error]);
+
+    SEInternalDataRequestBuilder *builder = [[SEInternalDataRequestBuilder alloc] initWithDataRequestService:_serviceMock];
+    XCTAssertThrows([factory createRequestWithBuilder:builder baseURL:_baseURL error:&error]);
+
+    XCTAssertThrows([factory createMultipartRequestWithBuilder:builder baseURL:_baseURL boundary:@"boundary" error:&error]);
 }
 
 @end


### PR DESCRIPTION
Added plenty of unit tests covering URL request factory in all its flavors:
- Direct requests through `POST:...`, `GET:`, etc.
- Download requests.
- Builder requests (both multipart and not multipart).
- Unsafe requests.

Along with that made a few improvements, namely:
- Allow raw data to be passed as body and not be serialized. This is also allowed with builder now.
- Made public headers be included with framework path (`#import <ServiceEssentials/Header.h>`).
- Marked `authorizationHeader` property as `atomic`, since under the hood it's protected with a mutex.
- Fixed a typo in `forkey` -> `forKey`
